### PR TITLE
worldedit selection integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ repositories {
 		name = "Fuzs Mod Resources"
 		url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
 	}
+	maven {
+		name = "EngineHub Resources"
+		url = "https://maven.enginehub.org/repo/"
+	}
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
@@ -49,6 +53,9 @@ dependencies {
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
 	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+
+        // WorldEdit API for optional WorldEdit integration
+        modCompileOnlyApi "com.sk89q.worldedit:worldedit-fabric-mc${project.minecraft_version}:7.3.0-SNAPSHOT"
 }
 
 processResources {

--- a/src/main/java/de/z0rdak/yawp/commands/RegionCommands.java
+++ b/src/main/java/de/z0rdak/yawp/commands/RegionCommands.java
@@ -28,6 +28,8 @@ import de.z0rdak.yawp.util.LocalRegions;
 import de.z0rdak.yawp.util.StickException;
 import de.z0rdak.yawp.util.StickType;
 import de.z0rdak.yawp.util.StickUtil;
+import de.z0rdak.yawp.util.WorldEditLinkUtil;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DimensionArgumentType;
@@ -630,6 +632,9 @@ public class RegionCommands {
         sendCmdFeedback(src, regionHierarchy);
         // State: [State]
         sendCmdFeedback(src, buildInfoComponent("cli.msg.info.region.state", buildRegionStateLink(region)));
+        if (FabricLoader.getInstance().isModLoaded("worldedit") ) {
+            WorldEditLinkUtil.regionToWorldEdit(src, region);
+        }
         return 0;
     }
 

--- a/src/main/java/de/z0rdak/yawp/util/WorldEditLinkCuboidRegionSelector.java
+++ b/src/main/java/de/z0rdak/yawp/util/WorldEditLinkCuboidRegionSelector.java
@@ -1,0 +1,71 @@
+package de.z0rdak.yawp.util;
+
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.math.BlockVector3;
+
+import de.z0rdak.yawp.core.region.IMarkableRegion;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import javax.annotation.Nullable;
+
+
+public class WorldEditLinkCuboidRegionSelector extends CuboidRegionSelector {
+
+	protected ServerCommandSource src;
+	protected IMarkableRegion region;
+	
+    /**
+     * Create a new region selector with the given two positions.
+     *
+     * @param world the world
+     * @param position1 position 1
+     * @param position2 position 2
+     */
+    public WorldEditLinkCuboidRegionSelector(ServerCommandSource src, IMarkableRegion region, @Nullable World world, BlockVector3 position1, BlockVector3 position2) {
+        super(world, position1, position2);
+        this.src = src;
+        this.region = region;
+    }
+    
+    protected void maybeSendToYapw() {
+    	if (src==null || region == null) {
+    		return;
+    	}
+		WorldEditLinkUtil.worldEditToRegion(src, region);    	
+    }
+    
+    @Override
+    public void learnChanges() {
+    	super.learnChanges();
+    	maybeSendToYapw();
+    }
+    
+    @Override
+    public void clear() {
+    	// Break the link between the worldedit region and the yawp region
+    	src = null;
+    	region = null;
+    	super.clear();
+    }
+    
+    @Override
+    public boolean selectPrimary(BlockVector3 position, SelectorLimits limits) {
+    	boolean ret = super.selectPrimary(position, limits);
+    	maybeSendToYapw();
+    	return ret;
+    }
+
+    @Override
+    public boolean selectSecondary(BlockVector3 position, SelectorLimits limits) {
+    	boolean ret = super.selectSecondary(position, limits);
+    	maybeSendToYapw();
+    	return ret;
+    }
+
+}
+

--- a/src/main/java/de/z0rdak/yawp/util/WorldEditLinkUtil.java
+++ b/src/main/java/de/z0rdak/yawp/util/WorldEditLinkUtil.java
@@ -1,0 +1,105 @@
+package de.z0rdak.yawp.util;
+
+import static de.z0rdak.yawp.util.MessageUtil.sendCmdFeedback;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.fabric.FabricAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.world.World;
+
+import de.z0rdak.yawp.core.area.IMarkableArea;
+import de.z0rdak.yawp.core.area.CuboidArea;
+import de.z0rdak.yawp.core.region.IMarkableRegion;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.util.math.BlockPos;
+
+public class WorldEditLinkUtil {
+
+	private WorldEditLinkUtil() {
+	}
+
+
+
+	public static int regionToWorldEdit(ServerCommandSource src, IMarkableRegion region) {
+
+		com.sk89q.worldedit.entity.Player actor = com.sk89q.worldedit.fabric.FabricAdapter.adaptPlayer(src.getPlayer());
+		LocalSession sess = WorldEdit.getInstance().getSessionManager().getIfPresent(actor);
+		if (sess==null) {
+			return 0;
+		}
+		World world = actor.getWorld();
+		if (world==null) {
+			return 0;
+		}
+		IMarkableArea area = region.getArea();
+		switch (area.getAreaType()) {
+		case CUBOID: {
+			CuboidArea cuboidArea = (CuboidArea) area;
+			BlockVector3 pos1 = FabricAdapter.adapt(cuboidArea.getAreaP1());
+			BlockVector3 pos2 = FabricAdapter.adapt(cuboidArea.getAreaP2());
+			CuboidRegionSelector we_reg_sel;
+			if (true) {
+			    // Live linking
+				we_reg_sel = new WorldEditLinkCuboidRegionSelector(src, region, world, pos1, pos2);
+			} else {
+				// Single shot
+			    we_reg_sel = new CuboidRegionSelector(world, pos1, pos2);
+			}
+			sess.setRegionSelector(world, we_reg_sel);
+			we_reg_sel.explainRegionAdjust(actor, sess);
+			return 0;
+		}
+		case CYLINDER:
+			throw new NotImplementedException("cylinder");
+		case SPHERE:
+			throw new NotImplementedException("sphere");
+		case POLYGON_3D:
+			throw new NotImplementedException("polygon");
+		case PRISM:
+			throw new NotImplementedException("prism");
+		default:
+			throw new IllegalArgumentException("Invalid area type");
+		}
+	}
+
+	public static int worldEditToRegion(ServerCommandSource src, IMarkableRegion region) {
+
+		com.sk89q.worldedit.entity.Player actor = com.sk89q.worldedit.fabric.FabricAdapter.adaptPlayer(src.getPlayer());
+		LocalSession sess = WorldEdit.getInstance().getSessionManager().getIfPresent(actor);
+		if (sess==null) {
+			// Silently ignore calls from missing players
+			return 0;
+		}
+		World world = actor.getWorld();
+		if (world==null) {
+			// FIXME - add error message
+			return 0;
+		}
+		Region we_region;
+		try {
+			we_region = sess.getSelection(world);
+		} catch (IncompleteRegionException e) {
+			// FIXME - add error message
+			return 0;
+		}
+		if (we_region instanceof CuboidRegion) {
+			// Feed WorldEdit selection to YAWP
+			CuboidRegion we_cuboid = (CuboidRegion) we_region;
+			BlockPos pos1 = FabricAdapter.toBlockPos(we_cuboid.getPos1());
+			BlockPos pos2 = FabricAdapter.toBlockPos(we_cuboid.getPos2());
+			region.setArea(new CuboidArea(pos1, pos2));
+		} else {
+			// FIXME - add error message
+			return 0;
+		}
+		return 0;
+	}
+
+}


### PR DESCRIPTION
This is the initial integration with the WorldEdit selection mechanism. /wp region <world> <region> info puts the YAWP region into the WE selection. Subsequent WE commands such as //expand etc and WE tool uses update both the WE selection and the YAWP region, live. The link is broken on the first //desel command to WE.