### PR TITLE
1.21 build is also valid for 1.21.1

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
     "fabric-api": ">=0.100.0",
     "forgeconfigapiport": "*",
     "fabric": "*",
-    "minecraft": "1.21"
+    "minecraft": ["1.21","1.21.1"]
   }
 }


### PR DESCRIPTION
The 1.21 build is also valid for 1.21.1. Update metadata accordingly.