### PR TITLE
feat: add no-sign-edit flag

### DIFF
--- a/common/src/main/java/de/z0rdak/yawp/core/flag/RegionFlag.java
+++ b/common/src/main/java/de/z0rdak/yawp/core/flag/RegionFlag.java
@@ -52,6 +52,7 @@ public enum RegionFlag {
     MOB_GRIEFING("mob-griefing", FlagType.BOOLEAN_FLAG, Collections.singletonList(FlagCategory.ENVIRONMENT)),
     NO_FLIGHT("no-flight", FlagType.BOOLEAN_FLAG, Collections.singletonList(FlagCategory.PLAYER)),
     NO_PVP("no-pvp", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.ENTITY)),
+    NO_SIGN_EDIT("no-sign-edit", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),
     PLACE_BLOCKS("place-blocks", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),
     PLACE_FLUIDS("place-fluids", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),
     SCOOP_FLUIDS("scoop-fluids", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),

--- a/common/src/main/java/de/z0rdak/yawp/mixin/SignBlockMixin.java
+++ b/common/src/main/java/de/z0rdak/yawp/mixin/SignBlockMixin.java
@@ -1,0 +1,36 @@
+package de.z0rdak.yawp.mixin;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.SignBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static de.z0rdak.yawp.core.flag.RegionFlag.NO_SIGN_EDIT;
+import static de.z0rdak.yawp.handler.HandlerUtil.processCheck;
+import static de.z0rdak.yawp.util.text.MessageSender.sendFlagMsg;
+
+@Mixin(SignBlock.class)
+public class SignBlockMixin {
+
+    @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/SignBlock;openTextEdit(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/block/entity/SignBlockEntity;Z)V"), cancellable = true)
+    public void use(BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult, CallbackInfoReturnable<InteractionResult> cir) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(blockPos, NO_SIGN_EDIT, level.dimension(), player);
+        if (Services.EVENT.post(checkEvent)) {
+            return;
+        }
+        processCheck(checkEvent, deny -> {
+            cir.setReturnValue(InteractionResult.FAIL);
+            sendFlagMsg(deny);
+        });
+    }
+}

--- a/common/src/main/resources/assets/yawp/lang/en_us.json
+++ b/common/src/main/resources/assets/yawp/lang/en_us.json
@@ -356,6 +356,7 @@
   "flag.msg.deny.melee-wtrader": "The §9{flag}§r flag denies this action here!",
   "flag.msg.deny.no-flight": "The §9{flag}§r flag denies this action here!",
   "flag.msg.deny.no-pvp": "The §9{flag}§r flag denies this action here!",
+  "flag.msg.deny.no-sign-edit": "THe §9{flag}§r flag denies this action here!",
   "flag.msg.deny.place-blocks": "The §9{flag}§r flag denies this action here!",
   "flag.msg.deny.place-fluids": "The §9{flag}§r flag denies this action here!",
   "flag.msg.deny.scoop-fluids": "The §9{flag}§r flag denies this action here!",

--- a/common/src/main/resources/yawp.mixins.json
+++ b/common/src/main/resources/yawp.mixins.json
@@ -9,7 +9,8 @@
     "FrostWalkerEnchantmentMixin",
     "LeavesBlockMixin",
     "LightningEntityMixin",
-    "ServerWorldMixin"
+    "ServerWorldMixin",
+    "SignBlockMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
This pr adds the no-sign-edit flag, to disallow editing signs inside a region.

It was a request from this discord post: https://discord.com/channels/1010986742905585759/1309971623561924608 - and I also think it was a nice simple one to get going with.

Unfortunately the mixin is required since there is no native event to handle sign edits.

_What is the process for keeping feature parity on other versions, and what is the main version you want to develop for atm?_