### PR TITLE
feat: add snow-fall and snow-melt flags

### DIFF
--- a/common/src/main/java/de/z0rdak/yawp/core/flag/RegionFlag.java
+++ b/common/src/main/java/de/z0rdak/yawp/core/flag/RegionFlag.java
@@ -61,6 +61,8 @@ public enum RegionFlag {
     SHOVEL_PATH("shovel-path", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),
     SHULKER_TELEPORT_FROM_REGION("shulker-tp-from", FlagType.BOOLEAN_FLAG, Collections.singletonList(FlagCategory.ENTITY)),
     SLEEP("sleep", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.PLAYER, FlagCategory.BLOCK)),
+    SNOW_FALL("snow-fall", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.BLOCK, FlagCategory.ENVIRONMENT)),
+    SNOW_SMELTING("snow-smelting", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.BLOCK, FlagCategory.ENVIRONMENT)),
     SPAWNING_ALL("spawning-all", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.ENVIRONMENT, FlagCategory.ENTITY)),
     SPAWNING_ANIMAL("spawning-animal", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.ENVIRONMENT, FlagCategory.ENTITY)),
     SPAWNING_GOLEM("spawning-golem", FlagType.BOOLEAN_FLAG, Arrays.asList(FlagCategory.ENVIRONMENT, FlagCategory.ENTITY)),

--- a/common/src/main/java/de/z0rdak/yawp/mixin/BiomeMixin.java
+++ b/common/src/main/java/de/z0rdak/yawp/mixin/BiomeMixin.java
@@ -1,0 +1,33 @@
+package de.z0rdak.yawp.mixin;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Biome.class)
+public class BiomeMixin {
+
+    @Inject(method = "shouldSnow", at = @At(value = "RETURN", opcode = 1), cancellable = true)
+    public void onShouldSnow(LevelReader levelReader, BlockPos blockPos, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!(levelReader instanceof WorldGenLevel worldGenLevel)) {
+            return;
+        }
+
+        ServerLevel level = worldGenLevel.getLevel();
+        FlagCheckEvent checkEvent = new FlagCheckEvent(blockPos, RegionFlag.SNOW_FALL, level.dimension());
+
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            cir.setReturnValue(false);
+        });
+    }
+}

--- a/common/src/main/java/de/z0rdak/yawp/mixin/SnowLayerBlockMixin.java
+++ b/common/src/main/java/de/z0rdak/yawp/mixin/SnowLayerBlockMixin.java
@@ -1,0 +1,32 @@
+package de.z0rdak.yawp.mixin;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.SnowLayerBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SnowLayerBlock.class)
+public class SnowLayerBlockMixin {
+
+    @Inject(method = "randomTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/SnowLayerBlock;dropResources(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)V"), cancellable = true)
+    public void onRandomTick(BlockState blockState, ServerLevel level, BlockPos blockPos, RandomSource randomSource, CallbackInfo ci) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(blockPos, RegionFlag.SNOW_SMELTING, level.dimension());
+
+        if (Services.EVENT.post(checkEvent)) {
+            return;
+        }
+
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            ci.cancel();
+        });
+    }
+}

--- a/common/src/main/resources/yawp.mixins.json
+++ b/common/src/main/resources/yawp.mixins.json
@@ -5,12 +5,14 @@
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "BiomeMixin",
     "FireBlockMixin",
     "FrostWalkerEnchantmentMixin",
     "LeavesBlockMixin",
     "LightningEntityMixin",
     "ServerWorldMixin",
     "SignBlockMixin",
+    "SnowLayerBlockMixin",
     "stick.AnvilScreenHandlerMixin",
     "stick.ServerPlayerInteractionManagerMixin"
   ],


### PR DESCRIPTION
This PR adds the two flags suggested in #66 `snow-melting` and `snow-fall`

- `snow-fall` when disabled, stops the snow from building up on the ground.
- `snow-melting` when disabled, stops the snow layers from melting on the ground. (Only happens with light blocks nearby, not direct sunlight _vanilla mechanic_)