### PR TITLE
fix: add minecraft repo, to include lwjgl files to allow booting on mac

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -14,6 +14,12 @@ java {
 }
 
 repositories {
+    maven {
+        url "https://libraries.minecraft.net"
+        content {
+            includeModule("org.lwjgl", "lwjgl-freetype")
+        }
+    }
     mavenCentral()
     // https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository
     exclusiveContent {


### PR DESCRIPTION
fix: add minecraft maven repo, to include lwjgl files to allow booting on mac

When trying to boot newer MC versions on Mac, it fails with unable to find a certain LWJGL library, and is fixed by adding the minecraft.net maven repo, and including those files.

I can verify that, when testing ensure you can boot as normal and sync gradle as normal (Without this it's not possible for me to sync or even boot)

this should not be back ported to 1.20.1 - but should be backported to `multi/1.21.1`

### Error
```
A problem occurred configuring project ':forge'.
> Could not resolve all files for configuration ':forge:_compileJava_1'.
   > Could not find lwjgl-freetype-3.3.3-natives-macos-patch.jar (org.lwjgl:lwjgl-freetype:3.3.3).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/org/lwjgl/lwjgl-freetype/3.3.3/lwjgl-freetype-3.3.3-natives-macos-patch.jar
```