### PR TITLE
feat: add snow real magic compat

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,6 +7,13 @@ plugins {
 base {
     archivesName = "${mod_id}-${minecraft_version}-${project.name}"
 }
+
+repositories {
+    repositories {
+        maven { url = "https://api.modrinth.com/maven" }
+    }
+}
+
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
     mappings loom.officialMojangMappings()
@@ -18,6 +25,11 @@ dependencies {
     // 1.20.1
     // modImplementation "curse.maven:forge-config-api-port-fabric-547434:4583000"
     modImplementation "fuzs.forgeconfigapiport:forgeconfigapiport-fabric:8.0.0"
+
+    // Mod compats
+    // modImplementation "maven.modrinth:kiwi:vXiIlQ0y" // Snow Real Magic dependency
+    compileOnly "maven.modrinth:snow-real-magic:7gCL9H54"
+
 }
 
 loom {

--- a/fabric/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
+++ b/fabric/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
@@ -1,0 +1,50 @@
+package de.z0rdak.yawp.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (targetClassName.startsWith("snownee.snow")) {
+            return FabricLoader.getInstance().isModLoaded("snowrealmagic");
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/fabric/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
+++ b/fabric/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
@@ -1,0 +1,29 @@
+package de.z0rdak.yawp.mixin.integrations.snowrealmagic;
+
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.snow.WorldTickHandler;
+
+@Mixin(WorldTickHandler.class)
+public class SRMWorldTickHandlerMixin {
+
+    @Inject(method = "doSnow", at = @At(value = "INVOKE", target = "Lsnownee/snow/Hooks;convert(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;IIZ)Z", ordinal = 0), cancellable = true, remap = false)
+    private static void doSnow(ServerLevel level, BlockPos.MutableBlockPos pos, CallbackInfo ci) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(pos, RegionFlag.SNOW_FALL, level.dimension());
+        if (Services.EVENT.post(checkEvent)){
+            return;
+        }
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            ci.cancel();
+        });
+    }
+}

--- a/fabric/src/main/resources/yawp.fabric.mixins.json
+++ b/fabric/src/main/resources/yawp.fabric.mixins.json
@@ -4,6 +4,7 @@
   "package": "de.z0rdak.yawp.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "de.z0rdak.yawp.mixin.MixinPlugin",
   "mixins": [
     "flag.AbstractFireBlockMixin",
     "flag.EnderManEntityMixin",
@@ -50,7 +51,8 @@
     "flag.player.ThrownEnderPearlMixin",
     "flag.player.breeding.AnimalMixin",
     "flag.player.breeding.FrogMixin",
-    "flag.player.breeding.SnifferMixin"
+    "flag.player.breeding.SnifferMixin",
+    "integrations.snowrealmagic.SRMWorldTickHandlerMixin"
   ],
   "client": [
   ],

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -74,10 +74,18 @@ minecraft {
 
 sourceSets.main.resources.srcDir 'src/generated/resources'
 
+repositories {
+    maven { url = "https://api.modrinth.com/maven" }
+}
+
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":common")
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
+
+    // Mod compats
+    // implementation fg.deobf("maven.modrinth:kiwi:A4YxIHAO") // Snow Real Magic dependency
+    compileOnly fg.deobf("maven.modrinth:snow-real-magic:Z5A25ipN")
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/forge/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
+++ b/forge/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
@@ -1,0 +1,53 @@
+package de.z0rdak.yawp.mixin;
+
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String s) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // We use LoadingModList here, since the ModList is not instantiated at this point.
+        if (targetClassName.startsWith("snownee.snow")) {
+            return LoadingModList.get().getModFileById("snowrealmagic") != null;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/forge/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
+++ b/forge/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
@@ -1,0 +1,28 @@
+package de.z0rdak.yawp.mixin.integrations.snowrealmagic;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.snow.WorldTickHandler;
+
+@Mixin(WorldTickHandler.class)
+public class SRMWorldTickHandlerMixin {
+
+    @Inject(method = "doSnow", at = @At(value = "INVOKE", target = "Lsnownee/snow/Hooks;convert(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;IIZ)Z", ordinal = 0), cancellable = true, remap = false)
+    private static void doSnow(ServerLevel level, BlockPos.MutableBlockPos pos, CallbackInfo ci) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(pos, RegionFlag.SNOW_FALL, level.dimension());
+        if (Services.EVENT.post(checkEvent)){
+            return;
+        }
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            ci.cancel();
+        });
+    }
+}

--- a/forge/src/main/resources/yawp.forge.mixins.json
+++ b/forge/src/main/resources/yawp.forge.mixins.json
@@ -4,9 +4,11 @@
   "package": "de.z0rdak.yawp.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "de.z0rdak.yawp.mixin.MixinPlugin",
   "mixins": [
     "PlayerEntityMixin",
-    "TntBlockMixin"
+    "TntBlockMixin",
+    "integrations.snowrealmagic.SRMWorldTickHandlerMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
This PR fixes the mod compat issue with Snow Real Magic.

It does so by mixing in to their code, by adding a compile time dependency, and doing a conditional mixin load.

closes: #152 

_note: I will forward this PR to 1.21.1, but Snow Real Magic does not have a version for 1.21.4_