### PR TITLE
feat: add snow real magic compat

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -54,6 +54,9 @@ repositories {
             includeGroup 'curse.maven'
         }
     }
+    repositories {
+        maven { url = "https://api.modrinth.com/maven" }
+    }
     maven {
         name = "Fuzs Mod Resources"
         url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     // WorldEdit API for optional WorldEdit integration
     //modCompileOnlyApi "com.sk89q.worldedit:worldedit-fabric-mc${project.minecraft_version}:7.3.10-SNAPSHOT"
     //modImplementation "curse.maven:worldedit-225608:6013137"
+
+    // Snow Real Magic
+    // modImplementation "maven.modrinth:kiwi:LzP2xOQB" // Snow Real Magic dependency
+    modCompileOnly "maven.modrinth:snow-real-magic:FFW2DVUh"
 }
 
 loom {

--- a/fabric/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
+++ b/fabric/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
@@ -1,0 +1,49 @@
+package de.z0rdak.yawp.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.startsWith("snownee.snow")) {
+            return FabricLoader.getInstance().isModLoaded("snowrealmagic");
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/fabric/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
+++ b/fabric/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
@@ -1,0 +1,28 @@
+package de.z0rdak.yawp.mixin.integrations.snowrealmagic;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.snow.WorldTickHandler;
+
+@Mixin(WorldTickHandler.class)
+public class SRMWorldTickHandlerMixin {
+
+    @Inject(method = "doSnow", at = @At(value = "INVOKE", target = "Lsnownee/snow/Hooks;convert(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;IIZ)Z", ordinal = 0), cancellable = true, remap = false)
+    private static void doSnow(ServerLevel level, BlockPos.MutableBlockPos pos, CallbackInfo ci) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(pos, RegionFlag.SNOW_FALL, level.dimension());
+        if (Services.EVENT.post(checkEvent)){
+            return;
+        }
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            ci.cancel();
+        });
+    }
+}

--- a/fabric/src/main/resources/yawp.fabric.mixins.json
+++ b/fabric/src/main/resources/yawp.fabric.mixins.json
@@ -4,8 +4,10 @@
   "package": "de.z0rdak.yawp.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_21",
+  "plugin": "de.z0rdak.yawp.mixin.MixinPlugin",
   "mixins": [
     "ExplosionMixin",
+    "integrations.snowrealmagic.SRMWorldTickHandlerMixin",
     "flag.AbstractFireBlockMixin",
     "flag.EnderManEntityMixin",
     "flag.EntityMixin",

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 dependencies {
     api "fuzs.forgeconfigapiport:forgeconfigapiport-neoforge:21.1.3"
+
+    // Snow Real Magic
+    // implementation "maven.modrinth:kiwi:M8h5uYyf" // Snow Real Magic dependency
+    api "maven.modrinth:snow-real-magic:Dc0gkbuC"
 }
 
 neoForge {

--- a/neoforge/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
+++ b/neoforge/src/main/java/de/z0rdak/yawp/mixin/MixinPlugin.java
@@ -1,0 +1,49 @@
+package de.z0rdak.yawp.mixin;
+
+import net.neoforged.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String s) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String s, String mixinClassName) {
+        if (mixinClassName.startsWith("snownee.snow")) {
+            return LoadingModList.get().getModFileById("snowrealmagic") != null;
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/neoforge/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
+++ b/neoforge/src/main/java/de/z0rdak/yawp/mixin/integrations/snowrealmagic/SRMWorldTickHandlerMixin.java
@@ -1,0 +1,28 @@
+package de.z0rdak.yawp.mixin.integrations.snowrealmagic;
+
+import de.z0rdak.yawp.api.events.region.FlagCheckEvent;
+import de.z0rdak.yawp.core.flag.RegionFlag;
+import de.z0rdak.yawp.handler.HandlerUtil;
+import de.z0rdak.yawp.platform.Services;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.snow.WorldTickHandler;
+
+@Mixin(WorldTickHandler.class)
+public class SRMWorldTickHandlerMixin {
+
+    @Inject(method = "doSnow", at = @At(value = "INVOKE", target = "Lsnownee/snow/Hooks;convert(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;IIZ)Z", ordinal = 0), cancellable = true, remap = false)
+    private static void doSnow(ServerLevel level, BlockPos.MutableBlockPos pos, CallbackInfo ci) {
+        FlagCheckEvent checkEvent = new FlagCheckEvent(pos, RegionFlag.SNOW_FALL, level.dimension());
+        if (Services.EVENT.post(checkEvent)){
+            return;
+        }
+        HandlerUtil.processCheck(checkEvent, deny -> {
+            ci.cancel();
+        });
+    }
+}

--- a/neoforge/src/main/resources/yawp.neoforge.mixins.json
+++ b/neoforge/src/main/resources/yawp.neoforge.mixins.json
@@ -4,12 +4,14 @@
   "package": "de.z0rdak.yawp.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_21",
+  "plugin": "de.z0rdak.yawp.mixin.MixinPlugin",
   "mixins": [
     "TntBlockMixin",
     "flag.player.AxeItemMixin",
     "flag.player.BucketItemMixin",
     "flag.player.HoeItemMixin",
-    "flag.player.ShovelItemMixin"
+    "flag.player.ShovelItemMixin",
+    "integrations.snowrealmagic.SRMWorldTickHandlerMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION


1.21.1 forward of #153 

Snow Real Magic does no longer support forge, so therefore it only implements for fabric and neoforge.