### PR TITLE
start of 1.21.6 compatibility

### DIFF
--- a/common/src/main/java/de/z0rdak/yawp/handler/HandlerUtil.java
+++ b/common/src/main/java/de/z0rdak/yawp/handler/HandlerUtil.java
@@ -7,7 +7,7 @@ import de.z0rdak.yawp.core.region.IProtectedRegion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.FlyingMob;
+//import net.minecraft.world.entity.FlyingMob;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.animal.horse.SkeletonHorse;
@@ -67,7 +67,7 @@ public final class HandlerUtil {
     public static boolean isMonster(Entity entity) {
         return entity instanceof Enemy
                 || entity instanceof Slime
-                || entity instanceof FlyingMob
+//                || entity instanceof FlyingMob
                 || entity instanceof EnderDragon
                 || entity instanceof Shulker 
                 || entity instanceof ZombieHorse || entity instanceof SkeletonHorse;

--- a/fabric/src/main/java/de/z0rdak/yawp/mixin/flag/EntityMixin.java
+++ b/fabric/src/main/java/de/z0rdak/yawp/mixin/flag/EntityMixin.java
@@ -77,7 +77,7 @@ public abstract class EntityMixin {
      * Note: does not seem to trigger for players, which is fine
      */
     @Inject(method = "teleportCrossDimension", at = @At(value = "HEAD"), cancellable = true, allow = 1)
-    public void onChangeDimension(ServerLevel level, TeleportTransition teleportTransition, CallbackInfoReturnable<Entity> cir) {
+    public void onChangeDimension(ServerLevel level, ServerLevel level2, TeleportTransition teleportTransition, CallbackInfoReturnable<Entity> cir) {
         Entity self = (Entity) (Object) this;
         if (isServerSide(self.level())) {
             FlagCheckEvent checkEvent = new FlagCheckEvent(self.blockPosition(), USE_PORTAL, getDimKey(self));

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Every field you add must be added to the root build.gradle expandProps map.
 
 # Common
-minecraft_version=1.21.5
+minecraft_version=1.21.6
 mc_uuid=45c90175-34fa-4163-8d6a-0319bfb41d08
 mc_username=Z0rdak
 mc_accessToken=
@@ -18,7 +18,7 @@ description=Yet Another World Protector (YAWP) is a server-side mod to protect y
 resource_pack_desc=Internationalisation keys for Yet Another World Protector
 credits=Thanks to all contributors (see CREDITS.txt)!
 
-minecraft_version_range=[1.21.5, 1.22)
+minecraft_version_range=[1.21.6, 1.22)
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
 neo_form_version=1.21.5-20250325.162830
@@ -27,12 +27,12 @@ parchment_minecraft=1.21.4
 parchment_version=2025.03.23
 
 # Fabric
-fabric_version=0.124.0+1.21.5
+fabric_version=0.127.1+1.21.6
 fabric_loader_version=0.16.14
 
 # Forge
-forge_version=55.0.14
-forge_loader_version_range=[55,)
+forge_version=56.0.7
+forge_loader_version_range=[56,)
 
 # NeoForge
 neoforge_version=21.5.66-beta

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ plugins {
 }
 
 // This should match the folder name of the project, or else IDEA may complain (see https://youtrack.jetbrains.com/issue/IDEA-317606)
-rootProject.name = 'YAWP-MultiLoader-1.21.5'
+rootProject.name = 'YAWP-MultiLoader-1.21.6'
 include('common')
 include('fabric')
 include('neoforge')


### PR DESCRIPTION
The test for FlyingMob was removed since I could not figure out what it should be in 1.21.6. This needs to be fixed properly. Other than that this is mostly a version bump and fixing some function signatures.

This version seems to fulfil our needs, but only rules we actually use on any server were tested.